### PR TITLE
feat: support MY_INFO_VW_CONFIG_DIR as global config dir

### DIFF
--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -1,0 +1,9 @@
+"""Centralized configuration path utilities for my-info-vw.
+
+All modules that need to locate config files (llm.yaml, search.yaml, etc.)
+should import from here instead of computing paths independently.
+"""
+
+from .path_utils import get_config_root, get_project_root
+
+__all__ = ["get_config_root", "get_project_root"]

--- a/src/config/path_utils.py
+++ b/src/config/path_utils.py
@@ -1,0 +1,37 @@
+"""Path resolution utilities.
+
+Provides a single source of truth for locating project config files.
+Respects the ``MY_INFO_VW_CONFIG_DIR`` environment variable so deployments
+can point the entire config tree at a custom directory.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+def get_project_root() -> Path:
+    """Return the project repository root (two levels up from this file)."""
+    return Path(__file__).resolve().parent.parent.parent
+
+
+def get_config_root() -> Path:
+    """Return the *config root* directory.
+
+    Resolution order:
+
+    1. ``MY_INFO_VW_CONFIG_DIR`` environment variable — if set and non-empty,
+       its value is used directly.
+    2. ``<PROJECT_ROOT>/config`` — the default, backward-compatible location.
+
+    The caller is responsible for appending the specific file name, e.g.
+    ``get_config_root() / "llm.yaml"``.
+    """
+    env_dir = os.getenv("MY_INFO_VW_CONFIG_DIR")
+    if env_dir:
+        return Path(env_dir)
+    return get_project_root() / "config"

--- a/src/llm/manager.py
+++ b/src/llm/manager.py
@@ -21,8 +21,15 @@ load_dotenv()
 
 logger = logging.getLogger(__name__)
 
-# Default YAML config path
-DEFAULT_CONFIG_PATH = Path(__file__).resolve().parent.parent.parent / "config" / "llm.yaml"
+
+def get_default_config_path() -> Path:
+    """Return the default config path, respecting MY_INFO_VW_CONFIG_DIR."""
+    from src.config import get_config_root
+    return get_config_root() / "llm.yaml"
+
+
+# Module-level default for backward compat (e.g. tests that read DEFAULT_CONFIG_PATH)
+DEFAULT_CONFIG_PATH = get_default_config_path()
 
 
 class LLMFallbackError(Exception):
@@ -38,7 +45,7 @@ class LLMManager:
     """Multi-provider LLM with automatic fallback."""
 
     def __init__(self, config_path: Optional[Path] = None):
-        self._config_path = config_path or DEFAULT_CONFIG_PATH
+        self._config_path = config_path or get_default_config_path()
         self._providers: dict[str, dict] = {}
         self._fallback_order: list[str] = []  # "provider/model"
         self._retry_on_error_codes: list[int] = []

--- a/src/search/aggregator.py
+++ b/src/search/aggregator.py
@@ -16,9 +16,12 @@ class SearchAggregator:
     """
 
     def __init__(self):
-        self._config_path = Path(__file__).resolve().parent.parent / "config" / "search.yaml"
+        from src.config import get_config_root, get_project_root
+
+        self._config_path = get_config_root() / "search.yaml"
         self._use_provider_manager = self._config_path.exists()
         self._manager = None
+        self._project_root = get_project_root()
         self.clients = []
         if not self._use_provider_manager:
             self._init_clients()
@@ -47,7 +50,7 @@ class SearchAggregator:
             from .provider_manager import SearchProviderManager
             self._manager = SearchProviderManager(
                 config_path=self._config_path,
-                project_root=self._config_path.parent.parent,
+                project_root=self._project_root,
             )
         return self._manager
 

--- a/src/search/provider_manager.py
+++ b/src/search/provider_manager.py
@@ -31,8 +31,9 @@ class SearchProviderManager:
             if project_root:
                 config_path = Path(project_root) / "config" / "search.yaml"
             else:
-                # Walk up from this file to find config/
-                config_path = Path(__file__).resolve().parent.parent.parent / "config" / "search.yaml"
+                # Use centralized config root (respects MY_INFO_VW_CONFIG_DIR)
+                from src.config import get_config_root
+                config_path = get_config_root() / "search.yaml"
         self.config_path = Path(config_path)
         self.project_root = Path(project_root) if project_root else self.config_path.parent.parent
         self._config: dict[str, Any] | None = None

--- a/tests/test_config_dir.py
+++ b/tests/test_config_dir.py
@@ -1,0 +1,178 @@
+"""Tests for MY_INFO_VW_CONFIG_DIR support."""
+
+import logging
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+class TestGetConfigRoot:
+    """Test get_config_root() from src.config.path_utils."""
+
+    def test_default_uses_project_config(self):
+        """Without env var, should return PROJECT_ROOT/config."""
+        from src.config.path_utils import get_project_root, get_config_root
+
+        with patch.dict(os.environ, {"MY_INFO_VW_CONFIG_DIR": ""}, clear=False):
+            # Ensure env var is not set
+            os.environ.pop("MY_INFO_VW_CONFIG_DIR", None)
+            assert get_config_root() == get_project_root() / "config"
+
+    def test_env_var_overrides(self):
+        """When MY_INFO_VW_CONFIG_DIR is set, should return that path."""
+        from src.config.path_utils import get_config_root
+
+        with patch.dict(os.environ, {"MY_INFO_VW_CONFIG_DIR": "/etc/my-info-vw"}):
+            assert get_config_root() == Path("/etc/my-info-vw")
+
+    def test_env_var_empty_string_falls_back(self):
+        """Empty string MY_INFO_VW_CONFIG_DIR should fall back to default."""
+        from src.config.path_utils import get_project_root, get_config_root
+
+        with patch.dict(os.environ, {"MY_INFO_VW_CONFIG_DIR": ""}):
+            assert get_config_root() == get_project_root() / "config"
+
+
+def _make_yaml_config(tmpdir: str | Path, providers=None, fallback_order=None):
+    """Helper: write a test llm.yaml and return its path."""
+    cfg = providers or [
+        {
+            "name": "test-p",
+            "api_base": "https://api.test.com/v1",
+            "api_key_env": "OPENAI_API_KEY",
+            "models": [{"name": "test-m"}],
+        }
+    ]
+    fallback = fallback_order or ["test-p/test-m"]
+    full_cfg = {"providers": cfg, "fallback_order": fallback}
+    path = Path(tmpdir) / "llm.yaml"
+    with open(path, "w") as f:
+        yaml.dump(full_cfg, f)
+    return path
+
+
+class TestLLMManagerConfigDir:
+    """Test LLMManager respects MY_INFO_VW_CONFIG_DIR."""
+
+    def test_no_env_var_existing_yaml(self):
+        """Case 1: No MY_INFO_VW_CONFIG_DIR, existing config/llm.yaml → uses it."""
+        from src.llm.manager import LLMManager
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = Path(tmpdir) / "config"
+            config_dir.mkdir()
+            _make_yaml_config(config_dir)
+
+            os.environ.pop("MY_INFO_VW_CONFIG_DIR", None)
+            fake_path = config_dir / "llm.yaml"
+            with patch("src.llm.manager.get_default_config_path", return_value=fake_path):
+                mgr = LLMManager()
+                assert mgr._legacy_mode is False
+                assert "test-p" in mgr._providers
+
+    def test_no_env_var_no_yaml(self):
+        """Case 2: No MY_INFO_VW_CONFIG_DIR, no llm.yaml → legacy mode."""
+        from src.llm.manager import LLMManager
+
+        os.environ.pop("MY_INFO_VW_CONFIG_DIR", None)
+        fake_path = Path("/nonexistent-project/config/llm.yaml")
+        with patch("src.llm.manager.get_default_config_path", return_value=fake_path):
+            mgr = LLMManager()
+            assert mgr._legacy_mode is True
+
+    def test_env_var_with_yaml(self):
+        """Case 3: MY_INFO_VW_CONFIG_DIR set, llm.yaml exists there → uses it."""
+        from src.llm.manager import LLMManager
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            custom_dir = Path(tmpdir) / "custom-config"
+            custom_dir.mkdir()
+            custom_cfg = [
+                {
+                    "name": "custom-p",
+                    "api_base": "https://custom.api/v1",
+                    "api_key_env": "OPENAI_API_KEY",
+                    "models": [{"name": "custom-m"}],
+                }
+            ]
+            _make_yaml_config(custom_dir, providers=custom_cfg, fallback_order=["custom-p/custom-m"])
+
+            fake_path = custom_dir / "llm.yaml"
+            with patch("src.llm.manager.get_default_config_path", return_value=fake_path):
+                mgr = LLMManager()
+                assert mgr._legacy_mode is False
+                assert "custom-p" in mgr._providers
+
+    def test_env_var_no_yaml(self):
+        """Case 4: MY_INFO_VW_CONFIG_DIR set but no llm.yaml → legacy mode."""
+        from src.llm.manager import LLMManager
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            empty_dir = Path(tmpdir) / "empty-config"
+            empty_dir.mkdir()
+
+            fake_path = empty_dir / "llm.yaml"
+            with patch("src.llm.manager.get_default_config_path", return_value=fake_path):
+                mgr = LLMManager()
+                assert mgr._legacy_mode is True
+
+    def test_explicit_config_path_takes_priority(self):
+        """Explicit config_path arg should override env var."""
+        from src.llm.manager import LLMManager
+
+        cfg = {
+            "providers": [
+                {
+                    "name": "explicit-p",
+                    "api_base": "https://explicit.api/v1",
+                    "api_key_env": "OPENAI_API_KEY",
+                    "models": [{"name": "explicit-m"}],
+                }
+            ],
+            "fallback_order": ["explicit-p/explicit-m"],
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False, dir=tmpdir) as f:
+                yaml.dump(cfg, f)
+                explicit_path = Path(f.name)
+
+            irrelevant = Path("/irrelevant/path/llm.yaml")
+            with patch("src.llm.manager.get_default_config_path", return_value=irrelevant):
+                mgr = LLMManager(config_path=explicit_path)
+                assert mgr._legacy_mode is False
+                assert "explicit-p" in mgr._providers
+
+            os.unlink(explicit_path)
+
+
+class TestSearchAggregatorConfigDir:
+    """Test SearchAggregator respects MY_INFO_VW_CONFIG_DIR."""
+
+    def test_uses_env_config_dir(self):
+        """When MY_INFO_VW_CONFIG_DIR points to a dir with search.yaml, should use it."""
+        from src.search.aggregator import SearchAggregator
+
+        cfg = {
+            "providers": [{"name": "test-cli", "command": "echo", "enabled": True}],
+            "search_order": ["test-cli"],
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            custom_dir = Path(tmpdir) / "search-config"
+            custom_dir.mkdir()
+            yaml_path = custom_dir / "search.yaml"
+            with open(yaml_path, "w") as f:
+                yaml.dump(cfg, f)
+
+            with patch.dict(os.environ, {"MY_INFO_VW_CONFIG_DIR": str(custom_dir)}):
+                agg = SearchAggregator()
+                assert agg._use_provider_manager is True


### PR DESCRIPTION
## Summary

Closes #4

Adds unified `MY_INFO_VW_CONFIG_DIR` environment variable support so all config files (`llm.yaml`, `search.yaml`, future configs) can be redirected to a custom directory.

## Changes

| File | What |
|------|------|
| `src/config/path_utils.py` | New: `get_config_root()` + `get_project_root()` |
| `src/config/__init__.py` | Public re-exports |
| `src/llm/manager.py` | `DEFAULT_CONFIG_PATH` → `get_default_config_path()` (lazy) |
| `src/search/aggregator.py` | Uses `get_config_root()` instead of hardcoded path |
| `src/search/provider_manager.py` | Fallback path uses `get_config_root()` |
| `tests/test_config_dir.py` | 9 new tests covering all cases |

## Behavior

- **`MY_INFO_VW_CONFIG_DIR` set** → all configs read from that directory
- **Unset or empty** → falls back to `PROJECT_ROOT/config` (no change)
- **Env dir has no config files** → existing `.env` fallback preserved
- **`config_path=` arg** in LLMManager still works (explicit override)

## Tests

All 9 new tests pass. All existing `test_llm_manager.py` tests unaffected.