### PR TITLE
refactor: normalize LLM provider api_key_env naming and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,13 @@
+# ── LLM Provider API Keys ──────────────────────────────
+# Multi-provider mode (config/llm.yaml): set keys matching each provider's api_key_env
+BIGMODEL_API_KEY=sk-*********
 
-OPENAI_API_BASE_URL=https://...
-OPENAI_API_KEY=*********
-OPENAI_MODEL=gpt-xxx
+# Legacy single-model fallback: used when config/llm.yaml is absent
+# OPENAI_API_BASE_URL=https://...
+# OPENAI_API_KEY=*********
+# OPENAI_MODEL=glm-4.7
 
-
+# ── LangSmith Tracing (optional) ───────────────────────
 LANGCHAIN_TRACING_V2=true
 LANGCHAIN_API_KEY=******
 LANGCHAIN_PROJECT=my-info-vw
-

--- a/README.md
+++ b/README.md
@@ -48,16 +48,18 @@ uv sync
 
 ```yaml
 providers:
-  - name: my-provider
-    api_base: https://api.example.com/v1
-    api_key_env: OPENAI_API_KEY
+  - name: bigmodel-glm47
+    api_base: https://open.bigmodel.cn/api/coding/paas/v4
+    api_key_env: BIGMODEL_API_KEY
     models:
-      - name: gpt-4o
+      - name: glm-4.7
         temperature: 0.7
 
 fallback_order:
-  - my-provider/gpt-4o
+  - bigmodel-glm47/glm-4.7
 ```
+
+> **命名约定**：每个 LLM Provider 的 `api_key_env` 应使用与 Provider 相关的专属环境变量名（如 `BIGMODEL_API_KEY`），避免多个 Provider 共用 `OPENAI_API_KEY`。请在 `.env` 文件中设置对应的 key。
 
 **方式二：.env 单模型模式**
 

--- a/config/llm.yaml
+++ b/config/llm.yaml
@@ -1,7 +1,7 @@
 providers:
   - name: bigmodel-glm47
     api_base: https://open.bigmodel.cn/api/coding/paas/v4
-    api_key_env: OPENAI_API_KEY
+    api_key_env: BIGMODEL_API_KEY
     models:
       - name: glm-4.7
         temperature: 0.7
@@ -10,7 +10,7 @@ providers:
 
   - name: bigmodel-light
     api_base: https://open.bigmodel.cn/api/coding/paas/v4
-    api_key_env: OPENAI_API_KEY
+    api_key_env: BIGMODEL_API_KEY
     models:
       - name: glm-4.5-air
         temperature: 0.7


### PR DESCRIPTION
## Summary

Closes #12

## Changes

- `config/llm.yaml`: Renamed `api_key_env` from `OPENAI_API_KEY` to `BIGMODEL_API_KEY` for both providers
- `.env.example`: Added clear sections for multi-provider keys vs legacy single-model fallback
- `README.md`: Added naming convention note for `api_key_env` — each provider should use a unique env var name

## Breaking Change

Users who currently set `OPENAI_API_KEY` for YAML multi-provider mode need to rename it to `BIGMODEL_API_KEY` in their `.env`. Legacy single-model mode (when no YAML exists) is unaffected.