### PR TITLE
refactor: replace print statements in search aggregator with logging

### DIFF
--- a/info-check.py
+++ b/info-check.py
@@ -9,11 +9,19 @@ Usage:
 
 import sys
 import json
+import logging
 import argparse
 from dotenv import load_dotenv
 
 # Load environment variables
 load_dotenv()
+
+# Configure logging for all modules
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-5s [%(name)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
 
 from src.workflows.check import create_workflow
 

--- a/src/search/aggregator.py
+++ b/src/search/aggregator.py
@@ -1,11 +1,14 @@
 """Multi-channel search aggregator."""
 
+import logging
 from typing import List, Dict, Any
 from pathlib import Path
 
 from .tavily_search import TavilySearch
 from .jina_search import JinaSearch
 from .news_search import NewsSearch
+
+logger = logging.getLogger(__name__)
 
 
 class SearchAggregator:
@@ -31,17 +34,17 @@ class SearchAggregator:
         try:
             self.clients.append(("tavily", TavilySearch()))
         except Exception as e:
-            print(f"Tavily not available: {e}")
+            logger.warning("Tavily not available: %s", e)
 
         try:
             self.clients.append(("jina", JinaSearch()))
         except Exception as e:
-            print(f"Jina not available: {e}")
+            logger.warning("Jina not available: %s", e)
 
         try:
             self.clients.append(("news", NewsSearch()))
         except Exception as e:
-            print(f"News not available: {e}")
+            logger.warning("News not available: %s", e)
 
     @property
     def provider_manager(self):
@@ -67,9 +70,9 @@ class SearchAggregator:
                 for r in results:
                     r["search_source"] = source_name
                 all_results.extend(results)
-                print(f"[{source_name}] Found {len(results)} results")
+                logger.info("[%s] Found %d results", source_name, len(results))
             except Exception as e:
-                print(f"[{source_name}] Error: {e}")
+                logger.error("[%s] Error: %s", source_name, e)
 
         # Remove duplicates based on URL
         seen_urls = set()


### PR DESCRIPTION
## Summary

Closes #13

## Changes

- `src/search/aggregator.py`: All 5 `print()` calls replaced with `logger.info/warning/error`
- `info-check.py`: Added `logging.basicConfig()` at entrypoint for consistent format across all modules
- CLI user-facing output (banners, report text) intentionally kept as `print()`

## Log format

```
2026-03-16 13:30:00 INFO  [src.search.aggregator] [tavily] Found 3 results
2026-03-16 13:30:01 WARN  [src.search.aggregator] Jina not available: ...
2026-03-16 13:30:02 ERROR [src.search.aggregator] [jina] Error: ...
```