### PR TITLE
feat: add Dockerfile and basic CI pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,30 @@
+# Dependencies
+__pycache__/
+*.pyc
+*.pyo
+.venv/
+.pytest_cache/
+.ruff_cache/
+.coverage
+coverage.json
+*.egg-info/
+
+# Environment / secrets
+.env
+
+# IDE
+.vscode/
+.idea/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Development artifacts
+.mypy_cache/
+htmlcov/
+dist/
+build/
+
+# State (runtime)
+STATE.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  backend-lint:
+    name: Backend Lint (advisory)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install dependencies
+        run: uv sync --frozen
+      - name: Ruff check
+        run: uv run ruff check src/ tests/
+      - name: Ruff format check
+        run: uv run ruff format --check src/ tests/
+
+  backend-test:
+    name: Backend Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install dependencies
+        run: uv sync --frozen
+      - name: Run tests
+        run: uv run pytest tests/ --timeout=120 -q

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+# Stage 1: dependencies
+FROM python:3.13-slim AS deps
+
+RUN pip install --no-cache-dir uv
+
+WORKDIR /app
+
+# Copy dependency manifests first for better layer caching
+COPY pyproject.toml uv.lock ./
+
+# Install production dependencies only
+RUN uv sync --frozen --no-dev --no-install-project
+
+# Stage 2: runtime
+FROM python:3.13-slim AS runtime
+
+WORKDIR /app
+
+# Copy virtual environment from deps stage
+COPY --from=deps /app/.venv /app/.venv
+ENV PATH="/app/.venv/bin:$PATH"
+
+# Copy application source
+COPY src/ ./src/
+COPY config/ ./config/
+COPY info-check.py info-check.sh ./
+
+# Ensure entry point is executable
+RUN chmod +x info-check.sh
+
+# Runtime environment
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+
+# Default config directory (override with MY_INFO_VW_CONFIG_DIR)
+ENV MY_INFO_VW_CONFIG_DIR=/app/config
+
+ENTRYPOINT ["./info-check.sh"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,5 +24,25 @@ dev = [
     "pytest-xdist>=3.8.0",
 ]
 
+[tool.ruff]
+target-version = "py310"
+line-length = 120
+src = ["src", "tests"]
+
+[tool.ruff.lint]
+select = [
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes
+    "I",    # isort
+    "UP",   # pyupgrade
+    "B",    # flake8-bugbear
+    "SIM",  # flake8-simplify
+]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+
 [tool.hatch.build.targets.wheel]
 packages = ["src"]


### PR DESCRIPTION
## Summary

Closes #11

Add Dockerfile for standardized backend deployment and a basic CI workflow.

## Changes

| File | Description |
|------|-------------|
| `Dockerfile` | Multi-stage build (deps + runtime), Python 3.13 + uv |
| `.dockerignore` | Lean image: exclude venv, caches, secrets, IDE files |
| `.github/workflows/ci.yml` | Backend lint (advisory) + test on push/PR to main/dev |
| `pyproject.toml` | Add ruff config (E, W, F, I, UP, B, SIM) |

## Dockerfile highlights
- Multi-stage: deps cached separately from app code
- `MY_INFO_VW_CONFIG_DIR=/app/config` set by default
- Entry point: `info-check.sh`
- `PYTHONUNBUFFERED=1` for proper logging

## CI workflow
- **backend-lint**: ruff check + format (advisory, won't block)
- **backend-test**: `pytest tests/` with 120s timeout
- Triggers on push/PR to `main` and `dev`