### PR TITLE
feat: normalize LLM provider api_key_env naming

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,8 +49,11 @@ LLM 层:
 ### 添加新的 LLM Provider
 
 1. 编辑 `config/llm.yaml`，在 `providers` 列表中添加条目
-2. 将 API Key 存放在环境变量中，通过 `api_key_env` 引用
+2. 为每个 provider 使用专属的 API Key 环境变量名（如 `BIGMODEL_API_KEY`、`DEEPSEEK_API_KEY`），通过 `api_key_env` 引用
 3. 在 `fallback_order` 中安排优先级
+4. 在 `.env` 或环境中设置对应的 API Key
+
+> **命名约定**：每个 LLM provider 应使用专属的环境变量名，避免多个 provider 共用 `OPENAI_API_KEY`。`LLMManager` 会自动向后兼容——若指定的 `api_key_env` 未设置，会回退查找 `OPENAI_API_KEY`。
 
 ## 编码规范
 

--- a/README.md
+++ b/README.md
@@ -48,16 +48,26 @@ uv sync
 
 ```yaml
 providers:
-  - name: my-provider
-    api_base: https://api.example.com/v1
+  - name: openai-gpt4
+    api_base: https://api.openai.com/v1
     api_key_env: OPENAI_API_KEY
     models:
       - name: gpt-4o
         temperature: 0.7
 
+  - name: bigmodel-glm
+    api_base: https://open.bigmodel.cn/api/coding/paas/v4
+    api_key_env: BIGMODEL_API_KEY    # 使用 provider 专属变量名
+    models:
+      - name: glm-4.7
+        temperature: 0.7
+
 fallback_order:
-  - my-provider/gpt-4o
+  - openai-gpt4/gpt-4o
+  - bigmodel-glm/glm-4.7
 ```
+
+> **API Key 命名约定**：建议每个 provider 使用专属的环境变量名（如 `BIGMODEL_API_KEY`、`DEEPSEEK_API_KEY`），而非复用 `OPENAI_API_KEY`。系统会自动向后兼容——如果指定的 `api_key_env` 未设置，会回退到 `OPENAI_API_KEY` 查找。
 
 **方式二：.env 单模型模式**
 

--- a/config/llm.yaml
+++ b/config/llm.yaml
@@ -1,7 +1,7 @@
 providers:
   - name: bigmodel-glm47
     api_base: https://open.bigmodel.cn/api/coding/paas/v4
-    api_key_env: OPENAI_API_KEY
+    api_key_env: BIGMODEL_API_KEY
     models:
       - name: glm-4.7
         temperature: 0.7
@@ -10,7 +10,7 @@ providers:
 
   - name: bigmodel-light
     api_base: https://open.bigmodel.cn/api/coding/paas/v4
-    api_key_env: OPENAI_API_KEY
+    api_key_env: BIGMODEL_API_KEY
     models:
       - name: glm-4.5-air
         temperature: 0.7

--- a/src/llm/manager.py
+++ b/src/llm/manager.py
@@ -57,6 +57,33 @@ class LLMManager:
         self._load_config()
 
     # ------------------------------------------------------------------
+    # API key resolution
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _resolve_api_key(env_key: str) -> str:
+        """Resolve API key for a provider.
+
+        Resolution order:
+        1. The env var specified by ``api_key_env`` (e.g. ``BIGMODEL_API_KEY``).
+        2. If ``api_key_env`` is *not* ``OPENAI_API_KEY`` and the above is empty,
+           fall back to ``OPENAI_API_KEY`` for backward compatibility.
+
+        This allows projects to migrate from the legacy ``OPENAI_API_KEY`` to
+        provider-specific names without breaking existing deployments.
+        """
+        api_key = os.getenv(env_key, "")
+        if not api_key and env_key != "OPENAI_API_KEY":
+            api_key = os.getenv("OPENAI_API_KEY", "")
+            if api_key:
+                logger.info(
+                    "[LLM] env var %s not set, using OPENAI_API_KEY as fallback "
+                    "(set %s to silence this message)",
+                    env_key, env_key,
+                )
+        return api_key
+
+    # ------------------------------------------------------------------
     # Configuration loading
     # ------------------------------------------------------------------
 
@@ -76,7 +103,7 @@ class LLMManager:
         for prov in cfg.get("providers", []):
             name = prov["name"]
             env_key = prov.get("api_key_env", "OPENAI_API_KEY")
-            api_key = os.getenv(env_key, "")
+            api_key = self._resolve_api_key(env_key)
 
             # [P0] API Key pre-check
             if not api_key:

--- a/tests/test_api_key_env.py
+++ b/tests/test_api_key_env.py
@@ -1,0 +1,157 @@
+"""Tests for normalized api_key_env naming and backward compatibility."""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+class TestResolveApiKey:
+    """Test LLMManager._resolve_api_key backward compatibility."""
+
+    def test_returns_key_from_specified_env(self):
+        """When api_key_env var is set, use it directly."""
+        from src.llm.manager import LLMManager
+
+        with patch.dict(os.environ, {"MY_CUSTOM_API_KEY": "sk-custom-123"}):
+            key = LLMManager._resolve_api_key("MY_CUSTOM_API_KEY")
+        assert key == "sk-custom-123"
+
+    def test_falls_back_to_openai_key(self):
+        """When api_key_env var is unset, falls back to OPENAI_API_KEY."""
+        from src.llm.manager import LLMManager
+
+        with patch.dict(os.environ, {
+            "SOME_PROVIDER_KEY": "",
+            "OPENAI_API_KEY": "sk-openai-fallback",
+        }, clear=False):
+            # Ensure the specific key is empty
+            os.environ.pop("SOME_PROVIDER_KEY", None)
+            with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-openai-fallback"}):
+                key = LLMManager._resolve_api_key("SOME_PROVIDER_KEY")
+
+        assert key == "sk-openai-fallback"
+
+    def test_no_fallback_when_api_key_env_is_openai(self):
+        """When api_key_env is literally OPENAI_API_KEY, no extra fallback."""
+        from src.llm.manager import LLMManager
+
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-direct"}, clear=False):
+            key = LLMManager._resolve_api_key("OPENAI_API_KEY")
+
+        assert key == "sk-direct"
+
+    def test_both_empty(self):
+        """When both api_key_env and OPENAI_API_KEY are empty, return empty."""
+        from src.llm.manager import LLMManager
+
+        with patch.dict(os.environ, {
+            "BIGMODEL_API_KEY": "",
+            "OPENAI_API_KEY": "",
+        }):
+            key = LLMManager._resolve_api_key("BIGMODEL_API_KEY")
+
+        assert key == ""
+
+    def test_specific_key_takes_priority_over_openai(self):
+        """When both are set, specific key wins."""
+        from src.llm.manager import LLMManager
+
+        with patch.dict(os.environ, {
+            "BIGMODEL_API_KEY": "sk-bigmodel",
+            "OPENAI_API_KEY": "sk-openai",
+        }):
+            key = LLMManager._resolve_api_key("BIGMODEL_API_KEY")
+
+        assert key == "sk-bigmodel"
+
+
+class TestLLMManagerWithNormalizedKeys:
+    """Integration: LLMManager with provider-specific API key names."""
+
+    def test_bigmodel_key_used_directly(self):
+        """BIGMODEL_API_KEY set → loads provider successfully."""
+        from src.llm.manager import LLMManager
+
+        cfg = {
+            "providers": [
+                {
+                    "name": "bigmodel-glm47",
+                    "api_base": "https://open.bigmodel.cn/api/coding/paas/v4",
+                    "api_key_env": "BIGMODEL_API_KEY",
+                    "models": [{"name": "glm-4.7"}],
+                }
+            ],
+            "fallback_order": ["bigmodel-glm47/glm-4.7"],
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yaml_path = Path(tmpdir) / "llm.yaml"
+            with open(yaml_path, "w") as f:
+                yaml.dump(cfg, f)
+
+            with patch.dict(os.environ, {"BIGMODEL_API_KEY": "sk-test-bigmodel"}):
+                mgr = LLMManager(config_path=yaml_path)
+                assert mgr._legacy_mode is False
+                assert "bigmodel-glm47" in mgr._providers
+
+    def test_fallback_to_openai_key(self):
+        """BIGMODEL_API_KEY unset but OPENAI_API_KEY set → loads via fallback."""
+        from src.llm.manager import LLMManager
+
+        cfg = {
+            "providers": [
+                {
+                    "name": "bigmodel-glm47",
+                    "api_base": "https://open.bigmodel.cn/api/coding/paas/v4",
+                    "api_key_env": "BIGMODEL_API_KEY",
+                    "models": [{"name": "glm-4.7"}],
+                }
+            ],
+            "fallback_order": ["bigmodel-glm47/glm-4.7"],
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yaml_path = Path(tmpdir) / "llm.yaml"
+            with open(yaml_path, "w") as f:
+                yaml.dump(cfg, f)
+
+            env = {"OPENAI_API_KEY": "sk-test-openai-fallback"}
+            os.environ.pop("BIGMODEL_API_KEY", None)
+            with patch.dict(os.environ, env, clear=False):
+                mgr = LLMManager(config_path=yaml_path)
+                assert mgr._legacy_mode is False
+                assert "bigmodel-glm47" in mgr._providers
+
+    def test_no_keys_skips_provider(self):
+        """Neither BIGMODEL_API_KEY nor OPENAI_API_KEY → provider skipped."""
+        from src.llm.manager import LLMManager
+
+        cfg = {
+            "providers": [
+                {
+                    "name": "bigmodel-glm47",
+                    "api_base": "https://open.bigmodel.cn/api/coding/paas/v4",
+                    "api_key_env": "BIGMODEL_API_KEY",
+                    "models": [{"name": "glm-4.7"}],
+                }
+            ],
+            "fallback_order": ["bigmodel-glm47/glm-4.7"],
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yaml_path = Path(tmpdir) / "llm.yaml"
+            with open(yaml_path, "w") as f:
+                yaml.dump(cfg, f)
+
+            os.environ.pop("BIGMODEL_API_KEY", None)
+            os.environ.pop("OPENAI_API_KEY", None)
+            with patch.dict(os.environ, {"BIGMODEL_API_KEY": "", "OPENAI_API_KEY": ""}):
+                mgr = LLMManager(config_path=yaml_path)
+                assert "bigmodel-glm47" not in mgr._providers

--- a/tests/test_llm_manager.py
+++ b/tests/test_llm_manager.py
@@ -54,7 +54,7 @@ class TestConfigLoading:
         assert mgr._legacy_mode is True
 
     def test_skip_provider_with_missing_api_key(self):
-        """Test provider is skipped when API key env var is empty."""
+        """Test provider is skipped when API key env var is empty (no fallback either)."""
         from src.llm.manager import LLMManager
 
         cfg = {
@@ -72,10 +72,18 @@ class TestConfigLoading:
         with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
             yaml.dump(cfg, f)
             f.flush()
-            mgr = LLMManager(config_path=Path(f.name))
-
-        assert "no-key-provider" not in mgr._providers
-        os.unlink(f.name)
+            # Clear both the specific key and OPENAI_API_KEY to prevent fallback
+            old_openai = os.environ.pop("OPENAI_API_KEY", None)
+            old_nonexist = os.environ.pop("NONEXISTENT_API_KEY_12345", None)
+            try:
+                mgr = LLMManager(config_path=Path(f.name))
+                assert "no-key-provider" not in mgr._providers
+            finally:
+                if old_openai is not None:
+                    os.environ["OPENAI_API_KEY"] = old_openai
+                if old_nonexist is not None:
+                    os.environ["NONEXISTENT_API_KEY_12345"] = old_nonexist
+            os.unlink(f.name)
 
     def test_validate_fallback_order_unknown_entries(self, caplog):
         """Test that unknown fallback_order entries are logged as errors."""


### PR DESCRIPTION
## Summary

Closes #12

Refactors API key environment variable naming to use provider-specific names (e.g. `BIGMODEL_API_KEY`) instead of reusing `OPENAI_API_KEY`, while maintaining full backward compatibility.

## Changes

| File | What |
|------|------|
| `config/llm.yaml` | `api_key_env`: `OPENAI_API_KEY` → `BIGMODEL_API_KEY` |
| `src/llm/manager.py` | New `_resolve_api_key()`: tries specific key first, then falls back to `OPENAI_API_KEY` |
| `README.md` | Updated YAML example + naming convention note |
| `CONTRIBUTING.md` | Updated LLM Provider section with naming guidance |
| `tests/test_llm_manager.py` | Fixed test to account for fallback behavior |
| `tests/test_api_key_env.py` | 8 new tests for all resolution scenarios |

## Backward Compatibility

✅ If `BIGMODEL_API_KEY` is not set but `OPENAI_API_KEY` is, the system automatically falls back. No existing deployment breaks.

## Tests

31/31 pass (including 8 new + 23 existing)